### PR TITLE
POC of MONGOCRYPT-382

### DIFF
--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -51,10 +51,11 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 	kr := keyRetriever{coll: ce.keyVaultColl}
 	cir := collInfoRetriever{client: ce.keyVaultClient}
 	ce.crypt, err = driver.NewCrypt(&driver.CryptOptions{
-		KeyFn:        kr.cryptKeys,
-		CollInfoFn:   cir.cryptCollInfo,
-		KmsProviders: kmsProviders,
-		TLSConfig:    ceo.TLSConfig,
+		KeyFn:              kr.cryptKeys,
+		CollInfoFn:         cir.cryptCollInfo,
+		KmsProviders:       kmsProviders,
+		TLSConfig:          ceo.TLSConfig,
+		CredentialCallback: driver.CredentialCallbackFn(ceo.CredentialCallback),
 	})
 	if err != nil {
 		return nil, err

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -9,6 +9,7 @@ package mongo
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -65,7 +66,13 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 		} else {
 			// Use callback to fetch credentials using same method as MONGODB-AWS.
 			credentialCallback = func(kmsProvider string) interface{} {
-				panic("TODO: fetching credentials with MONGODB-AWS not implemented")
+				fmt.Println("TODO: fetching credentials with MONGODB-AWS not fully implemented. This only checks environment variables")
+				return map[string]map[string]interface{}{
+					"aws": {
+						"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
+						"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+					},
+				}
 			}
 		}
 	}

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -43,7 +43,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 	db, coll := splitNamespace(ceo.KeyVaultNamespace)
 	ce.keyVaultColl = ce.keyVaultClient.Database(db).Collection(coll, keyVaultCollOpts)
 
-	credentialCallback := func(kmsProvider string) interface{} {
+	credentialCallback := func() interface{} {
 		// By default, do nothing.
 		return nil
 	}
@@ -65,7 +65,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 			credentialCallback = ceo.CredentialCallback
 		} else {
 			// Use callback to fetch credentials using same method as MONGODB-AWS.
-			credentialCallback = func(kmsProvider string) interface{} {
+			credentialCallback = func() interface{} {
 				fmt.Println("TODO: fetching credentials with MONGODB-AWS not fully implemented. This only checks environment variables")
 				return map[string]map[string]interface{}{
 					"aws": {

--- a/mongo/client_encryption.go
+++ b/mongo/client_encryption.go
@@ -43,7 +43,7 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 	db, coll := splitNamespace(ceo.KeyVaultNamespace)
 	ce.keyVaultColl = ce.keyVaultClient.Database(db).Collection(coll, keyVaultCollOpts)
 
-	credentialCallback := func() interface{} {
+	credentialCallback := func(kmsProvider string) interface{} {
 		// By default, do nothing.
 		return nil
 	}
@@ -65,13 +65,11 @@ func NewClientEncryption(keyVaultClient *Client, opts ...*options.ClientEncrypti
 			credentialCallback = ceo.CredentialCallback
 		} else {
 			// Use callback to fetch credentials using same method as MONGODB-AWS.
-			credentialCallback = func() interface{} {
+			credentialCallback = func(kmsProvider string) interface{} {
 				fmt.Println("TODO: fetching credentials with MONGODB-AWS not fully implemented. This only checks environment variables")
-				return map[string]map[string]interface{}{
-					"aws": {
-						"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
-						"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
-					},
+				return map[string]interface{}{
+					"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
+					"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
 				}
 			}
 		}

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -430,7 +430,6 @@ func TestMongocrypt382PoC(t *testing.T) {
 
 	// Test with empty "aws" document and no callback set. Expect AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables to be used.
 	mt.Run("2 Empty aws document. No callback set", func(mt *mtest.T) {
-		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {},
 		}
@@ -452,7 +451,6 @@ func TestMongocrypt382PoC(t *testing.T) {
 			mt.Fatalf("CreateDataKey error: %v", err)
 		}
 		mt.Logf("Created key with uuid: %v", uuid)
-		assert.True(mt, callbackCalled, "expected callback to have been called")
 	})
 
 	// Test with non-empty "aws" document and callback set. Expect callback not to be called.

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -400,11 +400,8 @@ func TestMongocrypt382PoC(t *testing.T) {
 		ceOpts := options.ClientEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetCredentialCallback(func(kmsProvider string) interface{} {
+			SetCredentialCallback(func() interface{} {
 				callbackCalled = true
-				if kmsProvider != "aws" {
-					return nil
-				}
 
 				return map[string]map[string]interface{}{
 					"aws": {
@@ -470,7 +467,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 		ceOpts := options.ClientEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetCredentialCallback(func(kmsProvider string) interface{} {
+			SetCredentialCallback(func() interface{} {
 				callbackCalled = true
 				return nil
 			})

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -400,14 +400,13 @@ func TestMongocrypt382PoC(t *testing.T) {
 		ceOpts := options.ClientEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetCredentialCallback(func() interface{} {
+			SetCredentialCallback(func(kmsProvider string) interface{} {
 				callbackCalled = true
+				assert.Equal(mt, kmsProvider, "aws", "expected callback to have been called with 'aws' kmsProvider, got %v", kmsProvider)
 
-				return map[string]map[string]interface{}{
-					"aws": {
-						"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
-						"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
-					},
+				return map[string]interface{}{
+					"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
+					"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
 				}
 			})
 		ce, err := mongo.NewClientEncryption(mt.Client, ceOpts)
@@ -465,7 +464,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 		ceOpts := options.ClientEncryption().
 			SetKmsProviders(kmsProvidersMap).
 			SetKeyVaultNamespace("keyvault.datakeys").
-			SetCredentialCallback(func() interface{} {
+			SetCredentialCallback(func(kmsProvider string) interface{} {
 				callbackCalled = true
 				return nil
 			})

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -392,7 +392,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 	}
 
 	// Test with empty "aws" document and callback set. Expect callback to be called.
-	mt.Run("1 Callback set", func(mt *mtest.T) {
+	mt.Run("1 Empty aws document. Callback set", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {},
@@ -432,7 +432,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 	})
 
 	// Test with empty "aws" document and no callback set. Expect AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables to be used.
-	mt.Run("2 No callback set", func(mt *mtest.T) {
+	mt.Run("2 Empty aws document. No callback set", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {},
@@ -458,8 +458,8 @@ func TestMongocrypt382PoC(t *testing.T) {
 		assert.True(mt, callbackCalled, "expected callback to have been called")
 	})
 
-	// Test with empty "aws" document and callback set. Expect callback not to be called.
-	mt.Run("3 No callback set. Non-empty aws document.", func(mt *mtest.T) {
+	// Test with non-empty "aws" document and callback set. Expect callback not to be called.
+	mt.Run("3 Non-empty aws document. Callback set.", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {

--- a/mongo/integration/client_side_encryption_test.go
+++ b/mongo/integration/client_side_encryption_test.go
@@ -392,7 +392,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 	}
 
 	// Test with empty "aws" document and callback set. Expect callback to be called.
-	mt.Run("Callback set", func(mt *mtest.T) {
+	mt.Run("1 Callback set", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {},
@@ -405,9 +405,12 @@ func TestMongocrypt382PoC(t *testing.T) {
 				if kmsProvider != "aws" {
 					return nil
 				}
-				return bson.D{
-					{"accessKeyId", os.Getenv("AWS_ACCESS_KEY_ID")},
-					{"secretAccessKey", os.Getenv("SECRET_ACCESS_KEY")},
+
+				return map[string]map[string]interface{}{
+					"aws": {
+						"accessKeyId":     os.Getenv("AWS_ACCESS_KEY_ID"),
+						"secretAccessKey": os.Getenv("AWS_SECRET_ACCESS_KEY"),
+					},
 				}
 			})
 		ce, err := mongo.NewClientEncryption(mt.Client, ceOpts)
@@ -429,7 +432,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 	})
 
 	// Test with empty "aws" document and no callback set. Expect AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables to be used.
-	mt.Run("No callback set", func(mt *mtest.T) {
+	mt.Run("2 No callback set", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {},
@@ -456,7 +459,7 @@ func TestMongocrypt382PoC(t *testing.T) {
 	})
 
 	// Test with empty "aws" document and callback set. Expect callback not to be called.
-	mt.Run("No callback set. Non-empty aws document.", func(mt *mtest.T) {
+	mt.Run("3 No callback set. Non-empty aws document.", func(mt *mtest.T) {
 		callbackCalled := false
 		kmsProvidersMap := map[string]map[string]interface{}{
 			"aws": {

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 )
 
-type CredentialCallbackFn func() interface{}
+type CredentialCallbackFn func(kmsProvider string) interface{}
 
 // ClientEncryptionOptions represents all possible options used to configure a ClientEncryption instance.
 type ClientEncryptionOptions struct {

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -11,11 +11,14 @@ import (
 	"fmt"
 )
 
+type CredentialCallbackFn func(kmsProvider string) interface{}
+
 // ClientEncryptionOptions represents all possible options used to configure a ClientEncryption instance.
 type ClientEncryptionOptions struct {
-	KeyVaultNamespace string
-	KmsProviders      map[string]map[string]interface{}
-	TLSConfig         map[string]*tls.Config
+	KeyVaultNamespace  string
+	KmsProviders       map[string]map[string]interface{}
+	TLSConfig          map[string]*tls.Config
+	CredentialCallback CredentialCallbackFn
 }
 
 // ClientEncryption creates a new ClientEncryptionOptions instance.
@@ -115,6 +118,13 @@ func BuildTLSConfig(tlsOpts map[string]interface{}) (*tls.Config, error) {
 	return cfg, nil
 }
 
+// SetCredentialCallback sets an optional callback to supply credentials to a KMS provider.
+// @callback is called when needed. It is passed the name of the needed KMS provider.
+func (c *ClientEncryptionOptions) SetCredentialCallback(callback CredentialCallbackFn) *ClientEncryptionOptions {
+	c.CredentialCallback = callback
+	return c
+}
+
 // MergeClientEncryptionOptions combines the argued ClientEncryptionOptions in a last-one wins fashion.
 func MergeClientEncryptionOptions(opts ...*ClientEncryptionOptions) *ClientEncryptionOptions {
 	ceo := ClientEncryption()
@@ -131,6 +141,9 @@ func MergeClientEncryptionOptions(opts ...*ClientEncryptionOptions) *ClientEncry
 		}
 		if opt.TLSConfig != nil {
 			ceo.TLSConfig = opt.TLSConfig
+		}
+		if opt.CredentialCallback != nil {
+			ceo.CredentialCallback = ceo.CredentialCallback
 		}
 	}
 

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -143,7 +143,7 @@ func MergeClientEncryptionOptions(opts ...*ClientEncryptionOptions) *ClientEncry
 			ceo.TLSConfig = opt.TLSConfig
 		}
 		if opt.CredentialCallback != nil {
-			ceo.CredentialCallback = ceo.CredentialCallback
+			ceo.CredentialCallback = opt.CredentialCallback
 		}
 	}
 

--- a/mongo/options/clientencryptionoptions.go
+++ b/mongo/options/clientencryptionoptions.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 )
 
-type CredentialCallbackFn func(kmsProvider string) interface{}
+type CredentialCallbackFn func() interface{}
 
 // ClientEncryptionOptions represents all possible options used to configure a ClientEncryption instance.
 type ClientEncryptionOptions struct {

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -34,7 +34,7 @@ type KeyRetrieverFn func(ctx context.Context, filter bsoncore.Document) ([]bsonc
 // MarkCommandFn is a callback used to add encryption markings to a command.
 type MarkCommandFn func(ctx context.Context, db string, cmd bsoncore.Document) (bsoncore.Document, error)
 
-type CredentialCallbackFn func(kmsProvider string) interface{}
+type CredentialCallbackFn func() interface{}
 
 // CryptOptions specifies options to configure a Crypt instance.
 type CryptOptions struct {
@@ -207,8 +207,7 @@ func (c *crypt) executeStateMachine(ctx context.Context, cryptCtx *mongocrypt.Co
 		case mongocrypt.Ready:
 			return cryptCtx.Finish()
 		case mongocrypt.NeedKmsCredentials:
-			// Only "aws" is supported.
-			credentials := c.credentialCallback("aws")
+			credentials := c.credentialCallback()
 
 			var credentialsBSON []byte
 			var err error

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -99,8 +99,6 @@ func NewCrypt(opts *CryptOptions) (Crypt, error) {
 		return nil, err
 	}
 
-	mc.UseNeedCredentialsState()
-
 	c.mongoCrypt = mc
 	return c, nil
 }

--- a/x/mongo/driver/crypt.go
+++ b/x/mongo/driver/crypt.go
@@ -99,6 +99,8 @@ func NewCrypt(opts *CryptOptions) (Crypt, error) {
 		return nil, err
 	}
 
+	mc.UseNeedCredentialsState()
+
 	c.mongoCrypt = mc
 	return c, nil
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build cse
 // +build cse
 
 package mongocrypt
@@ -243,4 +244,8 @@ func (m *MongoCrypt) createErrorFromStatus() error {
 	defer C.mongocrypt_status_destroy(status)
 	C.mongocrypt_status(m.wrapped, status)
 	return errorFromStatus(status)
+}
+
+func (m *MongoCrypt) UseNeedCredentialsState() {
+	C.mongocrypt_setopt_use_need_kms_credentials_state(m.wrapped)
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt.go
@@ -38,6 +38,9 @@ func NewMongoCrypt(opts *options.MongoCryptOptions) (*MongoCrypt, error) {
 		wrapped: wrapped,
 	}
 
+	// Opt in to using the NeedCredentialsState before setProviderOptions.
+	crypt.UseNeedCredentialsState()
+
 	// set options in mongocrypt
 	if err := crypt.setProviderOptions(opts.KmsProviders); err != nil {
 		return nil, err

--- a/x/mongo/driver/mongocrypt/mongocrypt_context.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_context.go
@@ -4,6 +4,7 @@
 // not use this file except in compliance with the License. You may obtain
 // a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
 
+//go:build cse
 // +build cse
 
 package mongocrypt
@@ -100,4 +101,14 @@ func (c *Context) createErrorFromStatus() error {
 	defer C.mongocrypt_status_destroy(status)
 	C.mongocrypt_ctx_status(c.wrapped, status)
 	return errorFromStatus(status)
+}
+
+func (c *Context) ProvideKmsProviders(kmsProviders bsoncore.Document) error {
+	providersBinary := newBinaryFromBytes(kmsProviders)
+	defer providersBinary.close()
+
+	if ok := C.mongocrypt_ctx_provide_kms_providers(c.wrapped, providersBinary.wrapped); !ok {
+		return c.createErrorFromStatus()
+	}
+	return nil
 }

--- a/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_context_not_enabled.go
@@ -54,3 +54,7 @@ func (c *Context) Finish() (bsoncore.Document, error) {
 func (c *Context) Close() {
 	panic(cseNotSupportedMsg)
 }
+
+func (c *Context) ProvideKmsProviders (kmsProviders bsoncore.Document) error {
+	panic(cseNotSupportedMsg)
+}

--- a/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
+++ b/x/mongo/driver/mongocrypt/mongocrypt_not_enabled.go
@@ -52,3 +52,7 @@ func (m *MongoCrypt) CreateExplicitDecryptionContext(doc bsoncore.Document) (*Co
 func (m *MongoCrypt) Close() {
 	panic(cseNotSupportedMsg)
 }
+
+func (m *MongoCrypt) UseNeedCredentialsState() {
+	panic(cseNotSupportedMsg)
+}

--- a/x/mongo/driver/mongocrypt/state.go
+++ b/x/mongo/driver/mongocrypt/state.go
@@ -18,6 +18,7 @@ const (
 	NeedKms
 	Ready
 	Done
+	NeedKmsCredentials = 7
 )
 
 // String implements the Stringer interface.
@@ -37,6 +38,8 @@ func (s State) String() string {
 		return "Ready"
 	case Done:
 		return "Done"
+	case NeedKmsCredentials:
+		return "NeedKmsCredentials"
 	default:
 		return "Unknown State"
 	}


### PR DESCRIPTION
This is an PoC of the Go driver wrapping the new functionality of [MONGOCRYPT-382](https://jira.mongodb.org/browse/MONGOCRYPT-382). It applies the changes for `ClientEncryption`, and has a stub to fetch AWS credentials.

# Summary
In libmongocrypt bindings (the `/x/mongo/driver/mongocrypt` package):
- Always call `mongocrypt_setopt_use_need_kms_credentials_state` on a `mongocrypt_t`.
- Wrap the `mongocrypt_ctx_provide_kms_providers` function.
- Add constant for the `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state.
- When in the `MONGOCRYPT_CTX_NEED_KMS_CREDENTIALS` state, call a CredentialCallback and pass the resulting document to `mongocrypt_ctx_provide_kms_providers`

In the driver:
- Add `CredentialCallback` option to `ClientEncryptionOptions`.
- If `ClientEncryptionOptions.KmsProviders` includes an empty `"aws": {}`, then:
    - Remove the "aws" field from the KmsProviders map.
    - If `ClientEncryptionOptions.CredentialCallback` is not set:
        - Set `CredentialCallback` to a callback to fetch AWS credentials. This is a stub currently.
- Otherwise, `ClientEncryptionOptions.KmsProviders` does not include an empty `"aws": {}`.
    - Set `CredentialCallback` to a callback which returns an empty document.